### PR TITLE
fix: giving complete path of serverless function in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
     "functions": {
-      "api/**/*.ts": {
+      "app/api/**/*.ts": {
         "memory": 3008,
         "maxDuration": 60
       }


### PR DESCRIPTION
fix: giving complete path of serverless function in vercel.json